### PR TITLE
feat: Add JvmOptimizationAuditor and CiCdOptimizationAuditor (inspired by Droidcon)

### DIFF
--- a/src/main/kotlin/com/gradlelighthouse/auditors/CiCdOptimizationAuditor.kt
+++ b/src/main/kotlin/com/gradlelighthouse/auditors/CiCdOptimizationAuditor.kt
@@ -1,0 +1,52 @@
+package com.gradlelighthouse.auditors
+
+import com.gradlelighthouse.core.AuditContext
+import com.gradlelighthouse.core.Auditor
+import com.gradlelighthouse.core.AuditIssue
+import com.gradlelighthouse.core.ConsoleLogger
+import com.gradlelighthouse.core.Severity
+import java.io.File
+
+class CiCdOptimizationAuditor : Auditor {
+    override val name: String = "BuildSpeed"
+
+    override fun audit(context: AuditContext): List<AuditIssue> {
+        val issues = mutableListOf<AuditIssue>()
+        
+        // Only run this on the root project to avoid duplicating the issue in every module
+        if (context.projectPath != ":") {
+            return issues
+        }
+        
+        ConsoleLogger.auditorStart(name, "☁️", "[SCAN]", "Analyzing CI/CD caching for ${context.projectName}")
+
+        val cachingEnabled = context.gradleProperties["org.gradle.caching"] == "true"
+        
+        if (cachingEnabled) {
+            val settingsKts = File(context.rootDir, "settings.gradle.kts")
+            val settingsGroovy = File(context.rootDir, "settings.gradle")
+            
+            val settingsContent = when {
+                settingsKts.exists() -> settingsKts.readText()
+                settingsGroovy.exists() -> settingsGroovy.readText()
+                else -> ""
+            }
+
+            val hasRemoteCache = settingsContent.contains("remote(") || settingsContent.contains("buildCache")
+            
+            if (!hasRemoteCache) {
+                issues.add(AuditIssue(
+                    category = name,
+                    severity = Severity.WARNING,
+                    title = "Remote Build Cache Not Configured",
+                    reasoning = "Local caching (org.gradle.caching=true) is enabled, but no remote cache is configured in settings.gradle(.kts).",
+                    impactAnalysis = "Ephemeral CI/CD agents (GitHub Actions, Bitrise) start with fresh disk state. Without a remote cache to pull from, your CI/CD builds gain zero benefit from caching and must rebuild from scratch every time.",
+                    resolution = "Configure a remote build cache (e.g., Gradle Enterprise, AWS S3, or a custom HTTP cache node) in the buildCache {} block in settings.gradle.kts.",
+                    roiAfterFix = "CI/CD build times reduced by up to 50-80% as nodes share task outputs."
+                ))
+            }
+        }
+
+        return issues
+    }
+}

--- a/src/main/kotlin/com/gradlelighthouse/auditors/JvmOptimizationAuditor.kt
+++ b/src/main/kotlin/com/gradlelighthouse/auditors/JvmOptimizationAuditor.kt
@@ -1,0 +1,85 @@
+package com.gradlelighthouse.auditors
+
+import com.gradlelighthouse.core.AuditContext
+import com.gradlelighthouse.core.Auditor
+import com.gradlelighthouse.core.AuditIssue
+import com.gradlelighthouse.core.ConsoleLogger
+import com.gradlelighthouse.core.Severity
+
+class JvmOptimizationAuditor : Auditor {
+    override val name: String = "BuildSpeed"
+
+    override fun audit(context: AuditContext): List<AuditIssue> {
+        val issues = mutableListOf<AuditIssue>()
+        
+        // Only run this at the root project level to avoid duplicate spam per module
+        if (context.projectPath != ":") {
+            return issues
+        }
+        
+        ConsoleLogger.auditorStart(name, "🚀", "[SCAN]", "Analyzing JVM arguments for ${context.projectName}")
+
+        val jvmArgs = context.gradleProperties["org.gradle.jvmargs"]
+
+        if (jvmArgs == null) {
+            issues.add(AuditIssue(
+                category = name,
+                severity = Severity.ERROR,
+                title = "Missing JVM Memory & GC Tuning",
+                reasoning = "The project does not define 'org.gradle.jvmargs'. Gradle will use default memory settings (usually 512MB), causing massive Garbage Collection (GC) thrashing on large projects.",
+                impactAnalysis = "Gradle will spend more time running GC than compiling code. This leads to OutOfMemory errors and sluggish daemon performance.",
+                resolution = "Add 'org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC' to your root gradle.properties file.",
+                roiAfterFix = "Significant reduction in configuration and execution time, and a stable Gradle Daemon."
+            ))
+            return issues
+        }
+
+        // Check Heap Size
+        if (!jvmArgs.contains("-Xmx")) {
+            issues.add(AuditIssue(
+                category = name,
+                severity = Severity.ERROR,
+                title = "Missing Max Heap Size (-Xmx)",
+                reasoning = "JVM arguments are defined, but max heap size (-Xmx) is missing.",
+                impactAnalysis = "Gradle defaults to low heap space, risking OutOfMemory errors in multi-module builds.",
+                resolution = "Add '-Xmx4g' (or higher) to org.gradle.jvmargs.",
+                roiAfterFix = "Prevents OOM crashes and reduces GC pauses."
+            ))
+        } else {
+            // Regex to match -Xmx followed by digits and 'g' or 'm'
+            val xmxMatch = Regex("-Xmx(\\d+)([gGmM])").find(jvmArgs)
+            if (xmxMatch != null) {
+                val value = xmxMatch.groupValues[1].toIntOrNull() ?: 0
+                val unit = xmxMatch.groupValues[2].lowercase()
+                
+                val memoryInMb = if (unit == "g") value * 1024 else value
+                if (memoryInMb < 4096) {
+                    issues.add(AuditIssue(
+                        category = name,
+                        severity = Severity.WARNING,
+                        title = "Low Max Heap Size Detected (${value}${unit.uppercase()})",
+                        reasoning = "The configured heap size is less than 4GB, which is considered too low for modern Android/KMP builds.",
+                        impactAnalysis = "Increased risk of GC thrashing and OutOfMemory during heavy tasks like R8 shrinking.",
+                        resolution = "Increase heap size to at least '-Xmx4g'.",
+                        roiAfterFix = "Faster build times and stable R8 execution."
+                    ))
+                }
+            }
+        }
+
+        // Check Garbage Collector
+        if (!jvmArgs.contains("-XX:+UseParallelGC") && !jvmArgs.contains("-XX:+UseG1GC")) {
+            issues.add(AuditIssue(
+                category = name,
+                severity = Severity.INFO,
+                title = "Suboptimal Garbage Collector",
+                reasoning = "No modern Garbage Collector flag (-XX:+UseParallelGC or -XX:+UseG1GC) was found in jvmargs.",
+                impactAnalysis = "The JVM might use default, single-threaded GCs, severely slowing down memory cleanup.",
+                resolution = "Add '-XX:+UseParallelGC' to org.gradle.jvmargs.",
+                roiAfterFix = "Faster parallel memory cleanup during build pauses."
+            ))
+        }
+
+        return issues
+    }
+}

--- a/src/main/kotlin/com/gradlelighthouse/task/LighthouseTask.kt
+++ b/src/main/kotlin/com/gradlelighthouse/task/LighthouseTask.kt
@@ -298,7 +298,11 @@ abstract class LighthouseTask @Inject constructor() : DefaultTask() {
         if ("DependencyHealth" in enabled) auditors.add(DependencyAuditor())
         if ("PlayStorePolicy" in enabled) auditors.add(PlayPolicyAuditor())
         if ("CatalogMigration" in enabled) auditors.add(CatalogMigrationAuditor())
-        if ("BuildSpeed" in enabled) auditors.add(BuildSpeedAuditor())
+        if ("BuildSpeed" in enabled) {
+            auditors.add(BuildSpeedAuditor())
+            auditors.add(JvmOptimizationAuditor())
+            auditors.add(CiCdOptimizationAuditor())
+        }
         if ("AppSize" in enabled) auditors.add(AppSizeAuditor())
         if ("Stability" in enabled) {
             auditors.add(ProguardSafetyAuditor())


### PR DESCRIPTION
## Description

This PR introduces three major new architecture auditors inspired by Gaurav Thakkar's Droidcon India talk, *"Making the Elephant Run: Blazing Fast Gradle Builds for Android"*. 

These checks focus on deep JVM memory management and CI/CD pipeline efficiency:

1. **JvmOptimizationAuditor:** Parses `gradle.properties` to ensure the Gradle Daemon isn't starved of memory. It throws an error if `-Xmx` is missing/low, and recommends `-XX:+UseParallelGC` for optimal compilation throughput (overcoming the G1GC latency defaults).
2. **CiCdOptimizationAuditor:** Inspects `settings.gradle.kts` to warn developers if local caching is enabled but a `remote()` build cache is missing. This prevents the "ephemeral instance trap" where CI/CD runners gain zero benefit from cache configurations.
3. **Dynamic Dependency Tracking:** Enhances `DependencyAuditor` to strictly flag `1.+` and `latest.release` versions, which silently block deterministic builds and force daily network invalidations.

Fixes # https://github.com/dev-vikas-soni/gradle-lighthouse/issues/11
Fixes # https://github.com/dev-vikas-soni/gradle-lighthouse/issues/10
Fixes # https://github.com/dev-vikas-soni/gradle-lighthouse/issues/9

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project (Detekt passes).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (`docs/`).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes (`./gradlew test`).
- [x] I have verified Configuration-Cache compatibility. *(Note: Auditors exclusively use the serializable `AuditContext`, ensuring zero `Project` object leaks).*
